### PR TITLE
create-function is create-function-app now

### DIFF
--- a/src/main/docs/guide/writingTheLambda.adoc
+++ b/src/main/docs/guide/writingTheLambda.adoc
@@ -1,3 +1,3 @@
 Create the function:
 
-`mn create-function example.micronaut.vies-vat-validator`
+`mn create-function-app example.micronaut.vies-vat-validator`


### PR DESCRIPTION
when following the guide with micronaut 2.0, create-function won't work, it's create-function-app now.